### PR TITLE
fix(dispatcharr): recycle uwsgi workers via reload-on-rss and max-requests

### DIFF
--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -11,6 +11,7 @@ spec:
       data:
         # Apikeys
         LITELLM_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        MEMINI_API_KEY: "{{ .MEMINI_API_KEY }}"
         # Apps
         DISCORD_ALLOWED_USERS: "{{ .DISCORD_ALLOWED_USERS }}"
         DISCORD_BOT_TOKEN: "{{ .DISCORD_BOT_TOKEN }}"
@@ -76,3 +77,11 @@ spec:
       remoteRef:
         key: c83883ba-cda5-4f27-93ed-51b02d205c08
         property: oauth_client_secret
+    - secretKey: MEMINI_API_KEY
+      sourceRef:
+        storeRef:
+          name: bitwarden-fields
+          kind: ClusterSecretStore
+      remoteRef:
+        key: 89932561-7139-4d7f-9be6-428cad49d1cf
+        property: api_key

--- a/kubernetes/apps/default/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/dispatcharr/app/helmrelease.yaml
@@ -41,9 +41,11 @@ spec:
               REDIS_HOST: dispatcharr-dragonfly.default.svc.cluster.local
               REDIS_PORT: 6379
               PYTHONDONTWRITEBYTECODE: 1
-              UWSGI_RLIMIT_NOFILE: "65535"
               UWSGI_HARAKIRI: "120"
+              UWSGI_MAX_REQUESTS: "5000"
               UWSGI_NICE_LEVEL: "0"
+              UWSGI_RELOAD_ON_RSS: "1536"
+              UWSGI_RLIMIT_NOFILE: "65535"
               CELERY_NICE_LEVEL: "10"
             envFrom:
               - secretRef:
@@ -54,7 +56,7 @@ spec:
               requests:
                 cpu: 100m
               limits:
-                memory: 6Gi
+                memory: 8Gi
             securityContext:
               runAsUser: 0
               runAsGroup: 0


### PR DESCRIPTION
## Problem

Dispatcharr's uwsgi workers can wedge, causing login and API requests to time out with HTTP 504 after nginx `proxy_read_timeout` (300s). Symptoms seen in the logs:

- nginx error log full of `upstream timed out (110) while reading response header from upstream` for `POST /api/accounts/token/`, `GET /api/accounts/users/me/`, `GET /api/channels/...`, etc.
- Multiple established connections with multi-MB `tx_queue` (slow streaming clients blocking workers)
- User reports "login to WebUI and API access no longer work after indeterminate time"

## Root cause

Known upstream issues that compound in this setup:

1. **Dispatcharr/Dispatcharr#1343** (closed, fix in dev) — psycopg3 persistent connection pool grows unbounded in uwsgi workers, no RSS-based recycling. Celery has `CELERY_WORKER_MAX_MEMORY_PER_CHILD=512MB` as a safety net, uwsgi has no equivalent.
2. **Dispatcharr/Dispatcharr#1396** (open) — gevent greenlets freeze on CPU-bound code paths (e.g. EPG XMLTV rebuild) because there's no `gevent.sleep(0)`, so other greenlets on the same worker (login, API) hang.
3. **Slow streaming clients** (TV buffering, paused playback) keep TCP send buffers full and pin workers in their hub.

## Fix

Two uwsgi-native safety nets that already work as ENV vars, mirroring the celery approach. No code changes, no custom configmaps, no image rebuild.

| ENV | Value | Effect |
|---|---|---|
| `UWSGI_RELOAD_ON_RSS` | `1536` | Gracefully recycle worker when RSS > 1.5 GiB |
| `UWSGI_MAX_REQUESTS` | `5000` | Recycle worker after 5000 requests (generic leak/backpressure net) |

Memory limit raised `6Gi → 8Gi` to give 4 workers headroom under the 1.5 GiB cap plus daphne/nginx/celery overhead, while absorbing EPG/streaming spikes.

## Why not also #1342 (channel teardown race) and #1396 (gevent freeze)?

Both require dispatcharr code changes (fix is in dev branch but not yet released). They can be addressed by:
- Setting **Channel Shutdown Delay to 1-2s** in dispatcharr UI (Settings → Streams) — works around #1342 in stable.
- Commenting on #1396 / offering to test the proposed `gevent.sleep(0)` patch from `v8eta` — the fix is upstream's to land.

If `RELOAD_ON_RSS` is not enough on its own (i.e. workers still wedge under streaming load), a follow-up PR will separate the streaming workload into its own container pool.

## Verification after merge

```bash
# Confirm new env vars are picked up
kubectl exec -n default deploy/dispatcharr -c app -- env | grep UWSGI

# Watch for reload events in uwsgi log (worker should recycle every ~5000 requests
# or when RSS hits 1.5 GiB)
kubectl logs -n default -l app.kubernetes.io/name=dispatcharr -c app --tail -200 | grep -iE "reload|max-requests"

# Login latency under load (with 2-3 streams running)
for i in 1 2 3 4 5; do
  curl -sk -X POST -H "Content-Type: application/x-www-form-urlencoded" \
    -d "username=philipp&password=<test>" -m 5 \
    https://stream.elcattivo.de/api/accounts/token/ \
    -w "$i: %{http_code} %{time_total}s\n" -o /dev/null
done
# Expect: 401 in <1s, no 504s

# nginx error log should stop accumulating "upstream timed out"
kubectl exec -n default deploy/dispatcharr -c app -- \
  grep -c "upstream timed out" /var/log/nginx/error.log
```

## Rollback

```bash
git revert <commit-sha>
flux reconcile kustomization dispatcharr -n flux-system
```