### PR TITLE
fix(dispatcharr): actually apply uwsgi worker recycling via ini mount

### DIFF
--- a/kubernetes/apps/default/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/dispatcharr/app/helmrelease.yaml
@@ -41,11 +41,7 @@ spec:
               REDIS_HOST: dispatcharr-dragonfly.default.svc.cluster.local
               REDIS_PORT: 6379
               PYTHONDONTWRITEBYTECODE: 1
-              UWSGI_HARAKIRI: "120"
-              UWSGI_MAX_REQUESTS: "5000"
               UWSGI_NICE_LEVEL: "0"
-              UWSGI_RELOAD_ON_RSS: "1536"
-              UWSGI_RLIMIT_NOFILE: "65535"
               CELERY_NICE_LEVEL: "10"
             envFrom:
               - secretRef:
@@ -87,6 +83,11 @@ spec:
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 30
+            volumeMounts:
+              - name: uwsgi-ini
+                mountPath: /app/docker/uwsgi.modular.ini
+                subPath: uwsgi.modular.ini
+                readOnly: true
 
           celery:
             image: *image
@@ -108,6 +109,10 @@ spec:
                 cpu: 10m
               limits:
                 memory: 2Gi
+    volumes:
+      - name: uwsgi-ini
+        configMap:
+          name: dispatcharr-uwsgi-ini
     service:
       app:
         ports:

--- a/kubernetes/apps/default/dispatcharr/app/kustomization.yaml
+++ b/kubernetes/apps/default/dispatcharr/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./securitypolicy.yaml
+  - ./uwsgi-ini-configmap.yaml

--- a/kubernetes/apps/default/dispatcharr/app/uwsgi-ini-configmap.yaml
+++ b/kubernetes/apps/default/dispatcharr/app/uwsgi-ini-configmap.yaml
@@ -1,0 +1,97 @@
+---
+# ConfigMap overrides /app/docker/uwsgi.modular.ini in the dispatcharr
+# image. The upstream INI is hardcoded in the image and the env vars
+# (UWSGI_HARAKIRI, UWSGI_RELOAD_ON_RSS, UWSGI_MAX_REQUESTS,
+# UWSGI_RLIMIT_NOFILE) are silently dropped by `su -` in entrypoint.sh —
+# uwsgi never sees them. The maintainers acknowledged this in an INI
+# comment ("uWSGI exec-pre runs under 'su -' which strips Docker env
+# vars"). The only reliable override is to mount a full INI over the
+# image file.
+#
+# This INI is a verbatim copy of the upstream
+# ghcr.io/dispatcharr/dispatcharr:0.27.2 /app/docker/uwsgi.modular.ini
+# with three additions under "Worker recycling":
+#   * harakiri        = 120   (kill any single request stuck > 2 min)
+#   * reload-on-rss   = 1536  (recycle worker if RSS > 1.5 GiB)
+#   * max-requests    = 5000  (recycle worker after 5000 requests)
+# A reload-mercy of 60s lets in-flight API requests finish before the
+# worker is killed; the harakiri still bounds the worst case.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dispatcharr-uwsgi-ini
+data:
+  uwsgi.modular.ini: |
+    [uwsgi]
+    ; Modular deployment mode - external PostgreSQL, Redis, and Celery
+    ; Remove file creation commands since we're not logging to files anymore
+    ; exec-pre = mkdir -p /data/logs
+    ; exec-pre = touch /data/logs/uwsgi.log
+    ; exec-pre = chmod 666 /data/logs/uwsgi.log
+
+    ; Redis wait + flush is handled by the entrypoint in modular mode
+    ; (uWSGI exec-pre runs under 'su -' which strips Docker env vars)
+
+    ; Start Daphne for WebSocket support (required for real-time features)
+    ; Redis and Celery run in separate containers in modular mode
+    attach-daemon = daphne -b 0.0.0.0 -p 8001 dispatcharr.asgi:application
+
+    # Core settings
+    chdir = /app
+    module = dispatcharr.wsgi:application
+    virtualenv = /dispatcharrpy
+    master = true
+    env = DJANGO_SETTINGS_MODULE=dispatcharr.settings
+    env = USE_NGINX_ACCEL=true
+    socket = /app/uwsgi.sock
+    chmod-socket = 777
+    vacuum = true
+    die-on-term = true
+    static-map = /static=/app/static
+
+    # Worker management
+    workers = 4
+
+    # Optimize for streaming
+    http = 0.0.0.0:5656
+    http-keepalive = 1
+    buffer-size = 65536  # Increase buffer for large payloads
+    post-buffering = 4096  # Reduce buffering for real-time streaming
+    http-timeout = 600  # Prevent disconnects from long streams
+    socket-timeout = 600  # Prevent write timeouts when client buffers
+    lazy-apps = true  # Improve memory efficiency
+
+    # Async mode (use gevent for high concurrency)
+    gevent = 400  # Each unused greenlet costs ~2-4KB of memory
+    # Higher values have minimal performance impact when idle, but provide capacity for traffic spikes
+    # If memory usage becomes an issue, reduce this value
+
+    # Patch the stdlib (socket, threading, time, ...) before any app code
+    # loads so blocking calls yield to the gevent hub. Without this, a single
+    # blocking requests / DNS call freezes every greenlet on the
+    # worker. psycopg3 uses Python's socket layer, so no additional patching is needed.
+    gevent-early-monkey-patch = true
+    import = dispatcharr.gevent_patch
+
+    # Worker recycling (see commit message for rationale)
+    harakiri = 120
+    reload-on-rss = 1536
+    reload-mercy = 60
+    max-requests = 5000
+    # end Worker recycling
+
+    # Performance tuning
+    thunder-lock = true
+    log-4xx = true
+    log-5xx = true
+    disable-logging = false
+
+    # Logging configuration
+    # Enable console logging (stdout)
+    log-master = true
+    # Enable strftime formatting for timestamps
+    logformat-strftime = true
+    log-date = %%Y-%%m-%%d %%H:%%M:%%S,000
+    # Use formatted time with environment variable for log level
+    log-format = %(ftime) $(DISPATCHARR_LOG_LEVEL) uwsgi.requests Worker ID: %(wid) %(method) %(status) %(uri) %(msecs)ms
+    log-buffering = 1024  # Add buffer size limit for logging


### PR DESCRIPTION
## Follow-up to #4617

PR #4617 added four UWSGI_* env vars — **none of them took effect**.

### Why #4617 was a no-op

`entrypoint.sh` runs uwsgi via:
```bash
nice -n "$UWSGI_NICE_LEVEL" su - "$POSTGRES_USER" -c "cd /app && exec .../uwsgi $uwsgi_args"
```

`su -` starts a login shell that sources /etc/profile.d/dispatcharr.sh, which is built from a **hardcoded `variables` array** in entrypoint.sh. That array only contains UWSGI_NICE_LEVEL, so all other UWSGI_* env vars from the container are discarded before uwsgi ever sees them.

Verified directly in the running pod:
```
$ cat /proc/1/environ | grep UWSGI
UWSGI_HARAKIRI=120
UWSGI_MAX_REQUESTS=5000
UWSGI_NICE_LEVEL=0
UWSGI_RELOAD_ON_RSS=1536
UWSGI_RLIMIT_NOFILE=65535

$ cat /proc/254/environ | grep UWSGI   # the uwsgi master
(nothing)
```

The upstream maintainers already noted this in a comment inside uwsgi.modular.ini: `; (uWSGI exec-pre runs under 'su -' which strips Docker env vars)`. UWSGI_HARAKIRI=120 set in commit 334566d29 was also a silent no-op the whole time.

### Fix

The only reliable override is to mount a full uwsgi.ini over the image file. This PR:

1. Adds `app/uwsgi-ini-configmap.yaml` with a verbatim copy of `ghcr.io/dispatcharr/dispatcharr:0.27.2` `/app/docker/uwsgi.modular.ini` plus a 'Worker recycling' block: `harakiri = 120`, `reload-on-rss = 1536`, `reload-mercy = 60`, `max-requests = 5000`.
2. Mounts it read-only at /app/docker/uwsgi.modular.ini in the app container.
3. Removes the four dead-code env vars from helmrelease.yaml. (UWSGI_NICE_LEVEL stays — it is in the variables array and actually works.)
4. Keeps the 6 Gi → 8 Gi memory limit raise from #4617.
5. Adds the ConfigMap to kustomization.yaml.

### Verification after merge

```bash
# Confirm the new INI is mounted
kubectl exec -n default deploy/dispatcharr -c app -- grep -E '^reload-on-rss|^max-requests|^harakiri' /app/docker/uwsgi.modular.ini

# Trigger uwsgi stats dump; should show reload-on-rss, max-requests, harakiri
kubectl exec -n default deploy/dispatcharr -c app -- kill -SIGUSR1 254
kubectl logs -n default -l app.kubernetes.io/name=dispatcharr -c app --tail=100 | grep -E 'reload-on-rss|max-requests|harakiri = '

# Login latency under load (with 2-3 streams running)
for i in 1 2 3 4 5; do
  curl -sk -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
    -d 'username=philipp&password=<test>' -m 5 \
    https://stream.elcattivo.de/api/accounts/token/ \
    -w "$i: %{http_code} %{time_total}s\n" -o /dev/null
done

# Watch for actual recycling events
kubectl logs -n default -l app.kubernetes.io/name=dispatcharr -c app --tail=200 \
  | grep -iE 'reloading|reload|MAX_REQUESTS|harakiri'
```

### Rollback

```bash
git revert <commit-sha>
flux reconcile kustomization dispatcharr -n flux-system
```

The old uwsgi.modular.ini is back instantly because the volume mount disappears with the ConfigMap.