### PR TITLE
fix(dispatcharr): mount uwsgi.ini via chart's persistence

### DIFF
--- a/kubernetes/apps/default/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/dispatcharr/app/helmrelease.yaml
@@ -83,11 +83,6 @@ spec:
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 30
-            volumeMounts:
-              - name: uwsgi-ini
-                mountPath: /app/docker/uwsgi.modular.ini
-                subPath: uwsgi.modular.ini
-                readOnly: true
 
           celery:
             image: *image
@@ -109,10 +104,6 @@ spec:
                 cpu: 10m
               limits:
                 memory: 2Gi
-    volumes:
-      - name: uwsgi-ini
-        configMap:
-          name: dispatcharr-uwsgi-ini
     service:
       app:
         ports:
@@ -158,3 +149,9 @@ spec:
         globalMounts:
           - path: /tmp
             subPath: tmp
+      uwsgi-ini:
+        type: configMap
+        name: dispatcharr-uwsgi-ini
+        globalMounts:
+          - path: /app/docker/uwsgi.modular.ini
+            readOnly: true


### PR DESCRIPTION
## Follow-up to #4618

PR #4618 added the uwsgi-ini ConfigMap and ConfigMap kustomization entry, plus a Helm values mount via `controllers.dispatcharr.containers.app.volumeMounts` and a controller-level `volumes` entry. **Both paths are rejected by the bjw-s app-template chart schema:**

```
- at '/controllers/dispatcharr/containers/app': additional properties 'volumeMounts' not allowed
- at '/controllers/dispatcharr': additional properties 'volumes' not allowed
```

The chart deliberately generates volumeMounts only from the top-level `persistence` key (see `bjw-s/helm-charts containers/fields/_volumeMounts.tpl`). Each persistence item can be of type `persistentVolumeClaim`, `configMap`, `secret`, `emptyDir`, `hostPath`, etc.

### Fix

Move the mount into the existing `persistence` block as a `configMap` item referencing the standalone ConfigMap `dispatcharr-uwsgi-ini`:

```yaml
persistence:
  uwsgi-ini:
    type: configMap
    name: dispatcharr-uwsgi-ini
    globalMounts:
      - path: /app/docker/uwsgi.modular.ini
        readOnly: true
```

The chart will then create the volume + volumeMount automatically. The ConfigMap and kustomization.yaml from #4618 stay as-is.

### Verification after merge

```bash
# Watch the release succeed
flux get hr dispatcharr -n default
# kubectl exec into the new pod and check that the override is active
kubectl exec -n default deploy/dispatcharr -c app -- grep -E '^(harakiri|reload-on-rss|max-requests)' /app/docker/uwsgi.modular.ini
# Trigger uwsgi stats dump
kubectl exec -n default deploy/dispatcharr -c app -- kill -SIGUSR1 254
kubectl logs -n default -l app.kubernetes.io/name=dispatcharr -c app --tail=200 | grep -E 'reload-on-rss|max-requests|harakiri = '
```

### Rollback

```bash
git revert <commit-sha>
flux reconcile kustomization dispatcharr -n flux-system
```