### PR TITLE
fix(dispatcharr): mount uwsgi.ini as subPath (not over a file)

### DIFF
--- a/kubernetes/apps/default/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/dispatcharr/app/helmrelease.yaml
@@ -153,5 +153,6 @@ spec:
         type: configMap
         name: dispatcharr-uwsgi-ini
         globalMounts:
-          - path: /app/docker/uwsgi.modular.ini
+          - path: /app/docker
+            subPath: uwsgi.modular.ini
             readOnly: true


### PR DESCRIPTION
## Follow-up to #4619 (which fixed the chart-schema error)

PR #4619 made the chart happy by moving the mount into `persistence.uwsgi-ini`:

```yaml
uwsgi-ini:
  type: configMap
  name: dispatcharr-uwsgi-ini
  globalMounts:
    - path: /app/docker/uwsgi.modular.ini
      readOnly: true
```

This renders to a volumeMount with `mountPath: /app/docker/uwsgi.modular.ini`. The destination is a regular file in the image (the upstream uwsgi.modular.ini), not a directory. **runc refuses to mount a ConfigMap (which is a directory) on top of an existing file**, so the pod is in CrashLoopBackOff:

```
error mounting ".../volumes/kubernetes.io~configmap/uwsgi-ini"
to rootfs at "/app/docker/uwsgi.modular.ini":
move_mount ... flags=MS_RDONLY|MS_BIND|MS_REC: invalid argument
```

### Fix

Mount the parent directory and use subPath so only the single file `uwsgi.modular.ini` from the ConfigMap volume is bind-mounted onto the image's file:

```yaml
uwsgi-ini:
  type: configMap
  name: dispatcharr-uwsgi-ini
  globalMounts:
    - path: /app/docker
      subPath: uwsgi.modular.ini
      readOnly: true
```

The bjw-s chart's _volumeMounts.tpl template already supports subPath, so the schema stays valid.

### Quick unblock (if you want to skip the PR review)

The pod is CrashLoopBackOff right now. If you want to unblock immediately without waiting for the PR, you can apply the fix directly:

```bash
kubectl patch hr dispatcharr -n default --type=merge -p '{"spec":{"values":{"persistence":{"uwsgi-ini":{"globalMounts":[{"path":"/app/docker","subPath":"uwsgi.modular.ini","readOnly":true}]}}}}}}'
```

(or just merge this PR — flux reconcile should pick it up within a minute.)